### PR TITLE
change gzdeflate to gzcompress due to representation differences

### DIFF
--- a/PhpProj1/Php/imageLib.php
+++ b/PhpProj1/Php/imageLib.php
@@ -164,7 +164,7 @@ function makePng(&$data)
 
 	$dataBytes = call_user_func_array('array_merge', array_reverse($scanlines));
 	$rawData = call_user_func_array('pack', array_merge(array("C*"), $dataBytes));
-	$compressedData = gzdeflate($rawData);
+	$compressedData = gzcompress($rawData);
 	
 	$r->add(pack("C*", 137, 80, 78, 71, 13, 10, 26, 10)); // PNG header
 	


### PR DESCRIPTION
as mentioned in the [stackoverflow answer](https://stackoverflow.com/questions/621976/which-compression-method-to-use-in-php) :

> - **gzcompress()** uses the **_ZLIB format_**. It has a shorter header serving only to identify the compression format, DEFLATE compressed data, and a footer containing an ADLER32 checksum.
> - **gzdeflate()** uses the raw DEFLATE algorithm on its own, which is the basis for both of the other formats.

and as mentioned in the [PNG Specification](https://tools.ietf.org/html/rfc2083#page-29)

>  Deflate-compressed datastreams within PNG are stored in the **_"zlib" format_**, which has the structure: ...